### PR TITLE
Add CLI args for analyze_edf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # edf-eeg-analyzer
 Utility for analyzing EEG EDF files
+
+## Usage
+
+Run the CLI to compute absolute power bands:
+
+```bash
+python analyze_edf.py <input.edf> [-o OUTPUT_DIR]
+```
+
+The optional `-o` flag sets the directory for the generated
+`absolute_power.csv` and `absolute_power.xlsx` files. By default the files are
+written to the current working directory.
 # EDF → Absolute‑Power Utility  
 *(technical & managerial specification)*  
 

--- a/analyze_edf.py
+++ b/analyze_edf.py
@@ -1,3 +1,6 @@
+import argparse
+import os
+
 import mne
 import numpy as np
 import pandas as pd
@@ -55,4 +58,28 @@ def compute_absolute_power(edf_path):
     df.to_excel("absolute_power.xlsx", index=False)
     return df
 if __name__ == "__main__":
-    compute_absolute_power("/Users/emil/Desktop/map_1_020420250945_ec.edf")
+    parser = argparse.ArgumentParser(
+        description="Compute absolute power bands from an EDF file"
+    )
+    parser.add_argument(
+        "edf_path",
+        help="Path to the input EDF file"
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default=".",
+        help="Directory to write the CSV/XLSX results"
+    )
+    args = parser.parse_args()
+
+    # ensure output directory exists and run in that context so the
+    # compute_absolute_power function writes files there
+    output_dir = os.path.abspath(args.output_dir)
+    os.makedirs(output_dir, exist_ok=True)
+    cwd = os.getcwd()
+    try:
+        os.chdir(output_dir)
+        compute_absolute_power(args.edf_path)
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
- switch analyze_edf.py to argparse-based CLI
- let user choose output directory
- document CLI usage

## Testing
- `python analyze_edf.py -h` *(fails: ModuleNotFoundError: No module named 'mne')*

------
https://chatgpt.com/codex/tasks/task_e_6851cc1207448324b58ebe9a3b7875b6