### PR TITLE
Add tests and linting config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503
+count = True
+statistics = True

--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ Mapping is pure post‑processing:
 - SciPy 1.12 > `scipy.signal.get_window`.
 
 ---
+## Development
+
+Install dependencies, run the unit tests, and check linting:
+
+```bash
+pip install -r requirements.txt
+pip install pytest flake8
+pytest
+flake8 .
+```
+
+`flake8` is configured via `.flake8` and should report fewer than six warnings.
+
 
 > **Hand‑off to Codex:**  
 > 1. Create the repo and commit `PROJECT_SPEC.md`.  

--- a/tests/test_absolute_power.py
+++ b/tests/test_absolute_power.py
@@ -1,0 +1,16 @@
+import numpy as np
+import mne
+
+from analyze_edf import compute_absolute_power, BANDS
+
+
+def test_compute_absolute_power_columns(tmp_path):
+    sfreq = 256
+    data = np.zeros((1, sfreq))
+    info = mne.create_info(ch_names=["Fz"], sfreq=sfreq, ch_types="eeg")
+    raw = mne.io.RawArray(data, info)
+    edf_path = tmp_path / "dummy.edf"
+    mne.export.export_raw(raw, edf_path, fmt="edf")
+
+    df = compute_absolute_power(str(edf_path))
+    assert list(df.columns) == ["Channel"] + list(BANDS.keys())


### PR DESCRIPTION
## Summary
- add flake8 configuration file
- create minimal unit test for `compute_absolute_power`
- describe test & lint workflow in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d1fc30488324b8c0334ffd9ae6f3