### PR TITLE
Add power band labeling utility

### DIFF
--- a/band_labels.py
+++ b/band_labels.py
@@ -1,0 +1,37 @@
+"""Utilities for labeling absolute power values."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def label_power(value: float, thresholds: Dict[str, float]) -> str:
+    """Return categorical label for ``value`` based on ``thresholds``.
+
+    Parameters
+    ----------
+    value:
+        Absolute power value in µV².
+    thresholds:
+        Mapping of label -> threshold. The mapping should be ordered from
+        lowest to highest threshold. The function returns the label
+        associated with the highest threshold that is less than or equal to
+        ``value``.
+
+    Examples
+    --------
+    >>> t = {"VLO": 0.0, "LO": 1.0, "OK": 5.0, "HI": 10.0, "VHI": 20.0}
+    >>> label_power(7.0, t)
+    'OK'
+    """
+    if not thresholds:
+        raise ValueError("thresholds mapping cannot be empty")
+
+    sorted_items = sorted(thresholds.items(), key=lambda x: x[1])
+    chosen_label = sorted_items[0][0]
+    for label, thr in sorted_items:
+        if value >= thr:
+            chosen_label = label
+        else:
+            break
+    return chosen_label

--- a/tests/test_band_labels.py
+++ b/tests/test_band_labels.py
@@ -1,0 +1,24 @@
+import pytest
+
+from band_labels import label_power
+
+
+THRESHOLDS = {"VLO": 0.0, "LO": 1.0, "OK": 5.0, "HI": 10.0, "VHI": 20.0}
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (0.0, "VLO"),
+        (1.0, "LO"),
+        (4.9, "LO"),
+        (5.0, "OK"),
+        (9.9, "OK"),
+        (10.0, "HI"),
+        (19.9, "HI"),
+        (20.0, "VHI"),
+        (25.0, "VHI"),
+    ],
+)
+def test_label_power(value, expected):
+    assert label_power(value, THRESHOLDS) == expected


### PR DESCRIPTION
## Summary
- implement `band_labels.label_power` to categorize power values
- test the label mapping logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d5bda20c832490b1ea49e5c7d460