### PR TITLE
Format numeric columns for display

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -12,7 +12,12 @@ def main():
             tmp.write(uploaded_file.getbuffer())
             tmp_path = tmp.name
         df = compute_absolute_power(tmp_path)
-        st.dataframe(df)
+
+        df_display = df.copy()
+        for col in df_display.columns:
+            if df_display[col].dtype != "object":
+                df_display[col] = df_display[col].apply(lambda v: f"{v:.3e}")
+        st.dataframe(df_display)
 
         csv = df.to_csv(index=False).encode("utf-8")
         st.download_button("Download CSV", data=csv, file_name="absolute_power.csv", mime="text/csv")


### PR DESCRIPTION
## Summary
- format numeric columns in `streamlit_app.py` for display only

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy, pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6852ad57bcb48324a226385195d08c3a