### PR TITLE
Ensure temp EDF file is cleaned up

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,4 +1,5 @@
 import io
+import os
 import tempfile
 import streamlit as st
 from analyze_edf import compute_absolute_power
@@ -11,7 +12,10 @@ def main():
         with tempfile.NamedTemporaryFile(delete=False, suffix=".edf") as tmp:
             tmp.write(uploaded_file.getbuffer())
             tmp_path = tmp.name
-        df = compute_absolute_power(tmp_path)
+        try:
+            df = compute_absolute_power(tmp_path)
+        finally:
+            os.remove(tmp_path)
         st.dataframe(df)
 
         csv = df.to_csv(index=False).encode("utf-8")


### PR DESCRIPTION
## Summary
- remove temporary EDF file after computing absolute power
- guarantee cleanup even if analysis fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement mne==1.6.1)*

------
https://chatgpt.com/codex/tasks/task_e_6852ad59c03083249d479d8e57c6b8a7