### PR TITLE
Add output dir arg to compute_absolute_power

### DIFF
--- a/analyze_edf.py
+++ b/analyze_edf.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from pathlib import Path
 
 import mne
 import numpy as np
@@ -15,13 +16,16 @@ BANDS = {
     'Hi-Beta': (20, 30),
 }
 
-def compute_absolute_power(edf_path):
+def compute_absolute_power(edf_path, output_dir="."):
     """Return per-channel absolute power for an EDF recording.
 
     Parameters
     ----------
     edf_path : str or pathlib.Path
         Path to the EDF file to analyze.
+    output_dir : str or pathlib.Path, optional
+        Directory where ``absolute_power.csv`` and ``absolute_power.xlsx``
+        will be written. Defaults to the current working directory.
 
     Returns
     -------
@@ -30,9 +34,12 @@ def compute_absolute_power(edf_path):
 
     Notes
     -----
-    Writes ``absolute_power.csv`` and ``absolute_power.xlsx`` to the
-    current working directory.
+    Writes ``absolute_power.csv`` and ``absolute_power.xlsx`` to
+    ``output_dir``.
     """
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     raw = mne.io.read_raw_edf(edf_path, preload=True)
     
@@ -71,9 +78,11 @@ def compute_absolute_power(edf_path):
 
     df = pd.DataFrame(results)
     df = df[['Channel'] + list(BANDS.keys())]
-    
-    df.to_csv("absolute_power.csv", index=False)
-    df.to_excel("absolute_power.xlsx", index=False)
+
+    csv_path = out_dir / "absolute_power.csv"
+    xlsx_path = out_dir / "absolute_power.xlsx"
+    df.to_csv(csv_path, index=False)
+    df.to_excel(xlsx_path, index=False)
     return df
 
 
@@ -110,13 +119,7 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     output_dir = os.path.abspath(args.output_dir)
-    os.makedirs(output_dir, exist_ok=True)
-    cwd = os.getcwd()
-    try:
-        os.chdir(output_dir)
-        df = compute_absolute_power(args.edf_path)
-    finally:
-        os.chdir(cwd)
+    df = compute_absolute_power(args.edf_path, output_dir=output_dir)
     return df
 
 

--- a/tests/test_absolute_power.py
+++ b/tests/test_absolute_power.py
@@ -12,5 +12,11 @@ def test_compute_absolute_power_columns(tmp_path):
     edf_path = tmp_path / "dummy.edf"
     mne.export.export_raw(raw, edf_path, fmt="edf")
 
-    df = compute_absolute_power(str(edf_path))
+    df = compute_absolute_power(str(edf_path), output_dir=tmp_path)
     assert list(df.columns) == ["Channel"] + list(BANDS.keys())
+    csv_path = tmp_path / "absolute_power.csv"
+    xlsx_path = tmp_path / "absolute_power.xlsx"
+    assert csv_path.exists()
+    assert xlsx_path.exists()
+    csv_path.unlink()
+    xlsx_path.unlink()

--- a/tests/test_compute_absolute_power.py
+++ b/tests/test_compute_absolute_power.py
@@ -16,7 +16,13 @@ def _decode_sample_edf(tmp_path: Path) -> Path:
 
 def test_compute_absolute_power(tmp_path):
     edf_path = _decode_sample_edf(tmp_path)
-    df = compute_absolute_power(edf_path)
+    df = compute_absolute_power(edf_path, output_dir=tmp_path)
     assert not df.empty
     expected_cols = ["Channel", "Delta", "Theta", "Alpha", "Beta", "Hi-Beta"]
     assert list(df.columns) == expected_cols
+    csv_path = tmp_path / "absolute_power.csv"
+    xlsx_path = tmp_path / "absolute_power.xlsx"
+    assert csv_path.exists()
+    assert xlsx_path.exists()
+    csv_path.unlink()
+    xlsx_path.unlink()


### PR DESCRIPTION
## Summary
- allow specifying an output directory when computing absolute power
- pass temp dirs in tests and assert CSV/XLSX files are created

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6852ad5d29ac8324b4d4a6770269e07a