### PR TITLE
Ensure resampling handles float rates

### DIFF
--- a/analyze_edf.py
+++ b/analyze_edf.py
@@ -37,7 +37,7 @@ def compute_absolute_power(edf_path):
     raw = mne.io.read_raw_edf(edf_path, preload=True)
     
     # Resample to 256 Hz if necessary
-    if raw.info['sfreq'] != 256:
+    if abs(raw.info['sfreq'] - 256) > 1e-6:
         raw.resample(256)
     sfreq = raw.info['sfreq']
 

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -1,0 +1,17 @@
+import numpy as np
+import mne
+
+from analyze_edf import compute_absolute_power
+
+
+def test_resample_non_integer(tmp_path, capsys):
+    sfreq = 255.5
+    data = np.zeros((1, int(sfreq)))
+    info = mne.create_info(ch_names=["Fz"], sfreq=sfreq, ch_types="eeg")
+    raw = mne.io.RawArray(data, info)
+    edf_path = tmp_path / "non_int.edf"
+    mne.export.export_raw(raw, edf_path, fmt="edf")
+
+    compute_absolute_power(str(edf_path))
+    captured = capsys.readouterr().out
+    assert "256.0 Hz" in captured


### PR DESCRIPTION
## Summary
- tolerate float sampling rates when deciding to resample
- verify that EDFs with non-integer rates are resampled to 256 Hz

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement mne==1.6.1)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6852ad5e931c83248c55d00ed0f9f77f